### PR TITLE
New features

### DIFF
--- a/intrin_rvv_new.hpp
+++ b/intrin_rvv_new.hpp
@@ -68,6 +68,15 @@ inline v_int16 v_load(short v, Args... vec) {
     return v_load({v, vec...});
 }
 
+inline v_float32 v_add(v_float32 f1, v_float32 f2) {
+    return vfadd(f1, f2, VTraits<v_float32>::nlanes);
+}
+
+template<typename... Args>
+inline v_float32 v_add(v_float32 f1, v_float32 f2, Args... vf) {
+    return v_add(vfadd(f1, f2, VTraits<v_float32>::nlanes), vf...);
+}
+
 
 inline vfloat32m1_t v_setall_f32(const float v) {
     return vfmv_v_f_f32m1(v, VTraits<v_float32>::nlanes);

--- a/intrin_rvv_new.hpp
+++ b/intrin_rvv_new.hpp
@@ -1,6 +1,10 @@
 #ifndef __INTRIN_RVV_HPP_NEW__
 #define __INTRIN_RVV_HPP_NEW__
 
+#ifndef RVV_MAX_VLEN
+#define RVV_MAX_VLEN 1024
+#endif
+
 #include <riscv_vector.h>
 
 using v_float32 = vfloat32m1_t;
@@ -14,6 +18,7 @@ struct VTraits<v_float32>
 {
     static unsigned int nlanes; 
     using lane_type = float;
+    static const unsigned int max_nlanes = RVV_MAX_VLEN/sizeof(lane_type);
 };
 
 template <>
@@ -21,6 +26,7 @@ struct VTraits<v_int16>
 {
     static unsigned int nlanes; 
     using lane_type = short;
+    static const unsigned int max_nlanes = RVV_MAX_VLEN/sizeof(lane_type);
 };
 
 unsigned int VTraits<v_float32>::nlanes = vsetvlmax_e32m1();

--- a/intrin_rvv_new.hpp
+++ b/intrin_rvv_new.hpp
@@ -45,6 +45,29 @@ inline void v_store(_Tp* ptr, const _Tpvec& a) \
 OPENCV_HAL_IMPL_RVV_LOADSTORE_OP(v_int16, short, VTraits<v_int16>::nlanes, 16, i16)
 OPENCV_HAL_IMPL_RVV_LOADSTORE_OP(v_float32, float, VTraits<v_float32>::nlanes, 32, f32)
 
+#include <initializer_list>
+#include <assert.h>
+
+inline v_float32 v_load(std::initializer_list<float> nScalars)
+{
+    // assert( nScalars.size() <= VTraits<v_float32>::nlanes);
+    return vle32_v_f32m1(nScalars.begin(), nScalars.size());
+}
+template<typename... Args>
+inline v_float32 v_load(float v, Args... vec) {
+    return v_load({v, vec...});
+}
+
+inline v_int16 v_load(std::initializer_list<short> nScalars)
+{
+    // assert( nScalars.size() <= VTraits<v_int16>::nlanes);
+    return vle16_v_i16m1(nScalars.begin(), nScalars.size());
+}
+template<typename... Args>
+inline v_int16 v_load(short v, Args... vec) {
+    return v_load({v, vec...});
+}
+
 
 inline vfloat32m1_t v_setall_f32(const float v) {
     return vfmv_v_f_f32m1(v, VTraits<v_float32>::nlanes);

--- a/test/makefile
+++ b/test/makefile
@@ -1,0 +1,19 @@
+LLVM_BUILD_PATH = /riscv/llvm-project/build/bin
+GNU_TC_PATH = /opt/RISCV
+
+src = $(wildcard *.cpp)
+target = $(patsubst %.cpp, %.out, ${src})
+
+.PHONY: all clean
+-include *.d
+
+%.out : %.cpp
+	$(LLVM_BUILD_PATH)/clang++ -march=rv64gcv --target=riscv64-unknown-linux-gnu --sysroot=$(GNU_TC_PATH)/sysroot --gcc-toolchain=$(GNU_TC_PATH) -O2 $< -MMD -o $@
+
+%. : %.out
+	$(GNU_TC_PATH)/bin/qemu-riscv64 -cpu rv64,x-v=true,vlen=128 $^
+	$(GNU_TC_PATH)/bin/qemu-riscv64 -cpu rv64,x-v=true,vlen=256 $^
+all: ${target}
+
+clean:
+	rm -f ${target}

--- a/test/nlanes.cpp
+++ b/test/nlanes.cpp
@@ -1,0 +1,32 @@
+////////////// Reverse //////////////
+#include "../intrin_rvv_new.hpp"
+#include <stdio.h>
+inline v_float32 v_reverse(const v_float32& a)  \
+{ \
+    float buf[VTraits<v_float32>::max_nlanes]; \
+    float temp; \
+    v_store(buf, a);
+    for (size_t i = 0; i <= VTraits<v_float32>::nlanes / 2; i++)
+    {
+        temp = buf[VTraits<v_float32>::nlanes-i-1];
+        buf[VTraits<v_float32>::nlanes-i-1] = buf[i];
+        buf[i] = temp;
+    }
+    return v_load(buf); \
+}
+
+float matA[] = {
+    1, 2,  3,  4, 
+    5, 6,  7,  8, 
+    9, 10, 11, 12, 
+    13,14, 15, 16};
+float ans[8];
+int main() {
+    // v_\w+x\d+\s*\(\s*\d+
+    v_float32 vans = v_load(matA);
+    vans = v_reverse(vans);
+    v_store(ans, vans);
+    printf("%u\n", VTraits<v_float32>::max_nlanes);
+    printf("%.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f\n", ans[0],ans[1],ans[2],ans[3],ans[4],ans[5],ans[6],ans[7]);
+    return 0;
+}

--- a/test/v_add.cpp
+++ b/test/v_add.cpp
@@ -1,0 +1,20 @@
+#include "../intrin_rvv_new.hpp"
+#include <stdio.h>
+float matA[] = {
+    1, 2,  3,  4, 
+    5, 6,  7,  8, 
+    9, 10, 11, 12, 
+    13,14, 15, 16};
+float ans[8];
+int main() {
+    v_float32 v0 = v_load(matA);
+    v_float32 v1 = v_load(matA+ VTraits<v_float32>::nlanes);
+    v_float32 v2 = v_load(matA+ 2*VTraits<v_float32>::nlanes);
+    v_float32 v3 = v_load(matA+ 3*VTraits<v_float32>::nlanes);
+    // v_float32 vans = v_add(v0, v1, v2, v3);
+    v_float32 vans = v_add(v0, v1, v2);
+    // v_float32 vans = v_add(v0, v1);
+    v_store(ans, vans);
+    printf("%.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f\n", ans[0],ans[1],ans[2],ans[3],ans[4],ans[5],ans[6],ans[7]);
+    return 0;
+}

--- a/test/v_load.cpp
+++ b/test/v_load.cpp
@@ -1,0 +1,17 @@
+#include "../intrin_rvv_new.hpp"
+#include <stdio.h>
+float matA[] = {
+    1, 2,  3,  4, 
+    5, 6,  7,  8, 
+    9, 10, 11, 12, 
+    13,14, 15, 16};
+float ans[8];
+int main() {
+    v_float32 vans = v_load(matA[0], matA[1], matA[2], matA[3]);
+    v_store(ans, vans);
+    printf("%.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f\n", ans[0],ans[1],ans[2],ans[3],ans[4],ans[5],ans[6],ans[7]);
+    return 0;
+}
+
+// regular expr. for constructor like vfloat32x4(1,2,3,4): 
+// v_\w+x\d+\s*\(\s*\d+


### PR DESCRIPTION
1.  Add `max_nlanes` as a member in class `VTraits`. Array declaration or initialization like `float foo[v_float32::nlanes]` will need to be modified to float `foo[VTraits<v_float32>::max_nlanes]`, where `max_nlanes` is a constant value given by compile-time or by default.
2. Add `v_load(<scalar>*n)` instead of scalars-to-vector constructor. See example in [v_load.cpp](https://github.com/hanliutong/rvv-ui/compare/master...new#diff-f69fe1367743ca50741c28c543da31f55371bcb71a5263d59afdb6b4d6f07601)
3. Add overloaded v_add for multiple operands. Since we can not overload operators in a built-in intrinsic type, we can not use v1 + v2 directly for two vercor objects. Instead, we can introduce v_add() and other arithmetic functions. 
`v1 + v2` -> `v_add(v1, v2)`
`v1 + v2 + v3` -> `v_add(v1, v2, v3)` (recommended) or `v_add(v_add(v1, v2), v3)`. Obviously, the first one is more concise.
