### PR TITLE
Enable RVV_UI in current code.

### DIFF
--- a/miniHAL/saxpy.cpp
+++ b/miniHAL/saxpy.cpp
@@ -17,9 +17,10 @@ int main() {
     size_t i = 0;
     int loopCnt = 0;
 
-    #if CV_SIMD
+    #if CV_SIMD || CV_SIMD_SCALABLE
+        SCALABLE_HAL_BEGIN
         printf("SIMD is used\n");
-        size_t vl = v_float32::nlanes;
+        size_t vl = VTraits<v_float32>::nlanes;
         v_float32 vx, vy;
         v_float32 va = v_setall_f32(a);
         float* outputPtr = output;
@@ -27,10 +28,16 @@ int main() {
             loopCnt++;
             vx = v_load(matX+i);
             vy = v_load(matY+i);
-            vy = va * vx + vy;
+            vy = v_add(vy, v_mul(va, vx));
             // vy = v_fma(va, vx, vy); //is also ok.
             v_store(outputPtr, vy);
         }
+        SCALABLE_HAL_END
+
+        #if CV_SIMD_SCALABLE
+            printf("scalable hal is used\n");
+        #endif
+
     #endif
 
     for (; i < n; ++i) {


### PR DESCRIPTION
This PR is used to show what we need to do with the existing source code when we enable the new RVV_UI backend.

In general, for the original SIMD code block to enable RVV(or others variable length UI backend), the following modifications are required:

1. Add macro `CV_SIMD_SCALABLE` in conditional compilation. (line 20)
2. Add macro `SCALABLE_HAL_BEGIN` and `SCALABLE_HAL_END` to warp the code block, in order to overwrite UI type, functions and so on. (line 21 and 35)
3. Modify the way of using nlanes. (line 23)
4. Rewrite operator as function call. (line 31)
5. Modify / rewrite others if needed.